### PR TITLE
Fix plot issue

### DIFF
--- a/5.ddpg.ipynb
+++ b/5.ddpg.ipynb
@@ -384,7 +384,7 @@
     "        episode_reward += reward\n",
     "        frame_idx += 1\n",
     "        \n",
-    "        if frame_idx % 1000 == 0:\n",
+    "        if frame_idx % max(1000, max_steps + 1) == 0:\n",
     "            plot(frame_idx, rewards)\n",
     "        \n",
     "        if done:\n",


### PR DESCRIPTION
Fix a plot issue when `max_steps` is larger than 1000. 
Not a bug but make the plot function more robust.
 